### PR TITLE
Issue 15 caching

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -211,6 +211,23 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 description = "Python HTTP for Humans."
@@ -319,4 +336,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "7bab58720cc7047656cec33d5b43d477c6873422a60ac63f4dc866daaff823f8"
+content-hash = "a525b6a1c954777b5b1e7039af4e3591c4ccb283f4696eae6eacad97f0b19dd4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requests = ">=2.0.0"
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.2"
 ruff = "^0.6.8"
+pytest-mock = "^3.14.0"
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/src/nmdc_geoloc_tools/__init__.py
+++ b/src/nmdc_geoloc_tools/__init__.py
@@ -1,1 +1,4 @@
-from nmdc_geoloc_tools.geotools import GeoEngine as GeoEngine
+from nmdc_geoloc_tools.geotools import elevation as elevation
+from nmdc_geoloc_tools.geotools import fao_soil_type as fao_soil_type
+from nmdc_geoloc_tools.geotools import landuse as landuse
+from nmdc_geoloc_tools.geotools import landuse_dates as landuse_dates

--- a/src/nmdc_geoloc_tools/geotools.py
+++ b/src/nmdc_geoloc_tools/geotools.py
@@ -6,7 +6,7 @@ import csv
 import json
 import xml.etree.ElementTree as ET
 from datetime import datetime
-from functools import cache
+from functools import cache, lru_cache
 from pathlib import Path
 from typing import Tuple
 
@@ -54,6 +54,7 @@ def _bbox(lat: float, lon: float, resolution: float) -> str:
     return f"{min_x},{min_y},{max_x},{max_y}"
 
 
+@lru_cache
 def elevation(latlon: LATLON) -> float:
     """
     Accepts decimal degrees latitude and longitude as an array (array[latitude, longitude]) and
@@ -92,6 +93,7 @@ def elevation(latlon: LATLON) -> float:
         raise ApiException(response.status_code)
 
 
+@lru_cache
 def fao_soil_type(latlon: LATLON) -> str:
     """
     Accepts decimal degrees latitude and longitude as an array (array[latitude, longitude]) and
@@ -138,6 +140,7 @@ def fao_soil_type(latlon: LATLON) -> str:
         raise ApiException(response.status_code)
 
 
+@lru_cache
 def landuse_dates(latlon: LATLON) -> []:
     """
     Accepts decimal degrees latitude and longitude as an array (array[latitude, longitude]) and
@@ -161,6 +164,7 @@ def landuse_dates(latlon: LATLON) -> []:
         raise ApiException(response.status_code)
 
 
+@lru_cache
 def landuse(latlon: LATLON, start_date, end_date) -> {}:
     """
     Accepts decimal degrees latitude and longitude as an array (array[latitude, longitude]), the

--- a/src/nmdc_geoloc_tools/geotools.py
+++ b/src/nmdc_geoloc_tools/geotools.py
@@ -1,3 +1,7 @@
+"""
+Functions which wrap ORNL Identify to retrieve elevation data in meters, soil types, and land use.
+"""
+
 import csv
 import json
 import xml.etree.ElementTree as ET
@@ -18,206 +22,204 @@ def read_data_csv(filename: str) -> list:
         return list(mapping)
 
 
-class GeoEngine:
+def _zobler_soil_type_lookup() -> list:
+    return read_data_csv("zobler_540_MixS_lookup.csv")
+
+
+def _envo_landuse_systems_lookup() -> list:
+    return read_data_csv("ENVO_Landuse_Systems_lookup.csv")
+
+
+def _envo_landuse_lookup() -> list:
+    return read_data_csv("ENVO_Landuse_lookup.csv")
+
+
+def _validate_latlon(latlon: LATLON):
+    lat = latlon[0]
+    lon = latlon[1]
+    if not -90 <= lat <= 90:
+        raise ValueError(f"Invalid Latitude: {lat}")
+    if not -180 <= lon <= 180:
+        raise ValueError(f"Invalid Longitude: {lon}")
+    return lat, lon
+
+
+def _bbox(lat: float, lon: float, resolution: float) -> str:
+    rem_x = (lon + 180) % resolution
+    rem_y = (lat + 90) % resolution
+    min_x = lon - rem_x
+    max_x = lon - rem_x + resolution
+    min_y = lat - rem_y
+    max_y = lat - rem_y + resolution
+    return f"{min_x},{min_y},{max_x},{max_y}"
+
+
+def elevation(latlon: LATLON) -> float:
     """
-    Wraps ORNL Identify to retrieve elevation data in meters, soil types, and land use.
+    Accepts decimal degrees latitude and longitude as an array (array[latitude, longitude]) and
+    returns the elevation value in meters as a float.
     """
+    lat, lon = _validate_latlon(latlon)
+    # Generate bounding box used in query from lat & lon. 0.008333333333333 comes from maplayer
+    # resolution provided by ORNL
+    bbox = _bbox(lat, lon, 0.008333333333333)
+    elevparams = {
+        "originator": "QAQCIdentify",
+        "SERVICE": "WMS",
+        "VERSION": "1.1.1",
+        "REQUEST": "GetFeatureInfo",
+        "SRS": "EPSG:4326",
+        "WIDTH": "5",
+        "HEIGHT": "5",
+        "LAYERS": "10003_1",
+        "QUERY_LAYERS": "10003_1",
+        "X": "2",
+        "Y": "2",
+        "INFO_FORMAT": "text/xml",
+        "BBOX": bbox,
+    }
+    response = requests.get(
+        "https://webmap.ornl.gov/ogcbroker/wms", params=elevparams
+    )
+    if response.status_code == 200:
+        elevxml = response.content.decode("utf-8")
+        if elevxml == "":
+            raise ValueError("No Elevation value returned")
+        root = ET.fromstring(elevxml)
+        results = root[3].text
+        return float(results)
+    else:
+        raise ApiException(response.status_code)
 
-    @property
-    def zobler_soil_type_lookup(self) -> list:
-        return read_data_csv("zobler_540_MixS_lookup.csv")
 
-    @property
-    def envo_landuse_systems_lookup(self) -> list:
-        return read_data_csv("ENVO_Landuse_Systems_lookup.csv")
+def fao_soil_type(latlon: LATLON) -> str:
+    """
+    Accepts decimal degrees latitude and longitude as an array (array[latitude, longitude]) and
+    returns the soil type as a string.
+    """
+    lat, lon = _validate_latlon(latlon)
+    # Generate bounding box used in query from lat & lon. 0.5 comes from maplayer resolution
+    # provided by ORNL
+    bbox = _bbox(lat, lon, 0.5)
 
-    @property
-    def envo_landuse_lookup(self) -> list:
-        return read_data_csv("ENVO_Landuse_lookup.csv")
+    fao_soil_params = {
+        "INFO_FORMAT": "text/xml",
+        "WIDTH": "5",
+        "originator": "QAQCIdentify",
+        "HEIGHT": "5",
+        "LAYERS": "540_1_band1",
+        "REQUEST": "GetFeatureInfo",
+        "SRS": "EPSG:4326",
+        "BBOX": bbox,
+        "VERSION": "1.1.1",
+        "X": "2",
+        "Y": "2",
+        "SERVICE": "WMS",
+        "QUERY_LAYERS": "540_1_band1",
+        "map": "/sdat/config/mapfile//540/540_1_wms.map",
+    }
+    response = requests.get(
+        "https://webmap.ornl.gov/cgi-bin/mapserv", params=fao_soil_params
+    )
+    if response.status_code == 200:
+        fao_soil_xml = response.content.decode("utf-8")
+        if fao_soil_xml == "":
+            raise ValueError("Empty string returned")
+        root = ET.fromstring(fao_soil_xml)
+        results = root[5].text
+        results = results.split(":")
+        results = results[1].strip()
+        for res in _zobler_soil_type_lookup():
+            if res[0] == results:
+                results = res[1]
+                return results
+        raise ValueError("Response mapping failed")
+    else:
+        raise ApiException(response.status_code)
 
-    @staticmethod
-    def _validate_latlon(latlon: LATLON):
-        lat = latlon[0]
-        lon = latlon[1]
-        if not -90 <= lat <= 90:
-            raise ValueError(f"Invalid Latitude: {lat}")
-        if not -180 <= lon <= 180:
-            raise ValueError(f"Invalid Longitude: {lon}")
-        return lat, lon
 
-    @staticmethod
-    def _bbox(lat: float, lon: float, resolution: float) -> str:
-        rem_x = (lon + 180) % resolution
-        rem_y = (lat + 90) % resolution
-        min_x = lon - rem_x
-        max_x = lon - rem_x + resolution
-        min_y = lat - rem_y
-        max_y = lat - rem_y + resolution
-        return f"{min_x},{min_y},{max_x},{max_y}"
+def landuse_dates(latlon: LATLON) -> []:
+    """
+    Accepts decimal degrees latitude and longitude as an array (array[latitude, longitude]) and
+    returns as array of valid dates (YYYY-MM-DD format) for the landuse requests.
+    """
+    lat, lon = _validate_latlon(latlon)
+    landuse_params = {"latitude": lat, "longitude": lon}
+    response = requests.get(
+        "https://modis.ornl.gov/rst/api/v1/MCD12Q1/dates", params=landuse_params
+    )
+    if response.status_code == 200:
+        landuse_dates_json = response.content.decode("utf-8")
+        if landuse_dates_json == "":
+            raise ValueError("No valid Landuse dates returned")
+        data = json.loads(landuse_dates_json)
+        valid_dates = []
+        for date in data["dates"]:
+            valid_dates.append(date["calendar_date"])
+        return valid_dates
+    else:
+        raise ApiException(response.status_code)
 
-    def get_elevation(self, latlon: LATLON) -> float:
-        """
-        Accepts decimal degrees latitude and longitude as an array (array[latitude, longitude]) and
-        returns the elevation value in meters as a float.
-        """
-        lat, lon = self._validate_latlon(latlon)
-        # Generate bounding box used in query from lat & lon. 0.008333333333333 comes from maplayer
-        # resolution provided by ORNL
-        bbox = self._bbox(lat, lon, 0.008333333333333)
-        elevparams = {
-            "originator": "QAQCIdentify",
-            "SERVICE": "WMS",
-            "VERSION": "1.1.1",
-            "REQUEST": "GetFeatureInfo",
-            "SRS": "EPSG:4326",
-            "WIDTH": "5",
-            "HEIGHT": "5",
-            "LAYERS": "10003_1",
-            "QUERY_LAYERS": "10003_1",
-            "X": "2",
-            "Y": "2",
-            "INFO_FORMAT": "text/xml",
-            "BBOX": bbox,
-        }
-        response = requests.get(
-            "https://webmap.ornl.gov/ogcbroker/wms", params=elevparams
-        )
-        if response.status_code == 200:
-            elevxml = response.content.decode("utf-8")
-            if elevxml == "":
-                raise ValueError("No Elevation value returned")
-            root = ET.fromstring(elevxml)
-            results = root[3].text
-            return float(results)
-        else:
-            raise ApiException(response.status_code)
 
-    def get_fao_soil_type(self, latlon: LATLON) -> str:
-        """
-        Accepts decimal degrees latitude and longitude as an array (array[latitude, longitude]) and
-        returns the soil type as a string.
-        """
-        lat, lon = self._validate_latlon(latlon)
-        # Generate bounding box used in query from lat & lon. 0.5 comes from maplayer resolution
-        # provided by ORNL
-        bbox = self._bbox(lat, lon, 0.5)
+def landuse(latlon: LATLON, start_date, end_date) -> {}:
+    """
+    Accepts decimal degrees latitude and longitude as an array (array[latitude, longitude]), the
+    start date (YYYY-MM-DD), and end date (YYYY-MM-DD) and returns a dictionary containing the
+    land use values for the classification systems for the dates requested.
+    """
+    lat, lon = _validate_latlon(latlon)
+    # function accepts dates in YYYY-MM-DD format, but API requires a unique format (AYYYYDOY)
+    date_format = "%Y-%m-%d"
+    start_date_obj = datetime.strptime(start_date, date_format)
+    end_date_obj = datetime.strptime(end_date, date_format)
 
-        fao_soil_params = {
-            "INFO_FORMAT": "text/xml",
-            "WIDTH": "5",
-            "originator": "QAQCIdentify",
-            "HEIGHT": "5",
-            "LAYERS": "540_1_band1",
-            "REQUEST": "GetFeatureInfo",
-            "SRS": "EPSG:4326",
-            "BBOX": bbox,
-            "VERSION": "1.1.1",
-            "X": "2",
-            "Y": "2",
-            "SERVICE": "WMS",
-            "QUERY_LAYERS": "540_1_band1",
-            "map": "/sdat/config/mapfile//540/540_1_wms.map",
-        }
-        response = requests.get(
-            "https://webmap.ornl.gov/cgi-bin/mapserv", params=fao_soil_params
-        )
-        if response.status_code == 200:
-            fao_soil_xml = response.content.decode("utf-8")
-            if fao_soil_xml == "":
-                raise ValueError("Empty string returned")
-            root = ET.fromstring(fao_soil_xml)
-            results = root[5].text
-            results = results.split(":")
-            results = results[1].strip()
-            for res in self.zobler_soil_type_lookup:
-                if res[0] == results:
-                    results = res[1]
-                    return results
-            raise ValueError("Response mapping failed")
-        else:
-            raise ApiException(response.status_code)
+    api_start_date = (
+        "A" + str(start_date_obj.year) + str(start_date_obj.strftime("%j"))
+    )
+    api_end_date = "A" + str(end_date_obj.year) + str(end_date_obj.strftime("%j"))
 
-    def get_landuse_dates(self, latlon: LATLON) -> []:
-        """
-        Accepts decimal degrees latitude and longitude as an array (array[latitude, longitude]) and
-        returns as array of valid dates (YYYY-MM-DD format) for the landuse requests.
-        """
-        lat, lon = self._validate_latlon(latlon)
-        landuse_params = {"latitude": lat, "longitude": lon}
-        response = requests.get(
-            "https://modis.ornl.gov/rst/api/v1/MCD12Q1/dates", params=landuse_params
-        )
-        if response.status_code == 200:
-            landuse_dates = response.content.decode("utf-8")
-            if landuse_dates == "":
-                raise ValueError("No valid Landuse dates returned")
-            data = json.loads(landuse_dates)
-            valid_dates = []
-            for date in data["dates"]:
-                valid_dates.append(date["calendar_date"])
-            return valid_dates
-        else:
-            raise ApiException(response.status_code)
-
-    def get_landuse(self, latlon: LATLON, start_date, end_date) -> {}:
-        """
-        Accepts decimal degrees latitude and longitude as an array (array[latitude, longitude]), the
-        start date (YYYY-MM-DD), and end date (YYYY-MM-DD) and returns a dictionary containing the
-        land use values for the classification systems for the dates requested.
-        """
-        lat, lon = self._validate_latlon(latlon)
-        # function accepts dates in YYYY-MM-DD format, but API requires a unique format (AYYYYDOY)
-        date_format = "%Y-%m-%d"
-        start_date_obj = datetime.strptime(start_date, date_format)
-        end_date_obj = datetime.strptime(end_date, date_format)
-
-        api_start_date = (
-            "A" + str(start_date_obj.year) + str(start_date_obj.strftime("%j"))
-        )
-        api_end_date = "A" + str(end_date_obj.year) + str(end_date_obj.strftime("%j"))
-
-        landuse_params = {
-            "latitude": lat,
-            "longitude": lon,
-            "startDate": api_start_date,
-            "endDate": api_end_date,
-            "kmAboveBelow": 0,
-            "kmLeftRight": 0,
-        }
-        response = requests.get(
-            "https://modis.ornl.gov/rst/api/v1/MCD12Q1/subset", params=landuse_params
-        )
-        if response.status_code == 200:
-            landuse = response.content.decode("utf-8")
-            results = {}
-            if landuse == "":
-                raise ValueError("No Landuse value returned")
-            data = json.loads(landuse)
-            for band in data["subset"]:
-                system = "NONE"
-                band["data"] = list(map(int, band["data"]))
-                for res in self.envo_landuse_systems_lookup:
-                    if res[1] == band["band"]:
-                        system = res[0]
-                for res in self.envo_landuse_lookup:
-                    if res[8] == system and int(res[1]) in band["data"]:
-                        envo_term = res[2]
-                        if envo_term == "":
-                            envo_term = "ENVO Term unavailable"
-                        entry = {
-                            "date": band["calendar_date"],
-                            "envo_term": envo_term,
-                            "system_description": res[6],
-                            "system_term": res[0],
-                        }
-                        try:
-                            results[system].append(entry)
-                        except KeyError:
-                            results[system] = []
-                            results[system].append(entry)
-            return results
-        else:
-            raise ApiException(response.status_code)
+    landuse_params = {
+        "latitude": lat,
+        "longitude": lon,
+        "startDate": api_start_date,
+        "endDate": api_end_date,
+        "kmAboveBelow": 0,
+        "kmLeftRight": 0,
+    }
+    response = requests.get(
+        "https://modis.ornl.gov/rst/api/v1/MCD12Q1/subset", params=landuse_params
+    )
+    if response.status_code == 200:
+        landuse = response.content.decode("utf-8")
+        results = {}
+        if landuse == "":
+            raise ValueError("No Landuse value returned")
+        data = json.loads(landuse)
+        for band in data["subset"]:
+            system = "NONE"
+            band["data"] = list(map(int, band["data"]))
+            for res in _envo_landuse_systems_lookup():
+                if res[1] == band["band"]:
+                    system = res[0]
+            for res in _envo_landuse_lookup():
+                if res[8] == system and int(res[1]) in band["data"]:
+                    envo_term = res[2]
+                    if envo_term == "":
+                        envo_term = "ENVO Term unavailable"
+                    entry = {
+                        "date": band["calendar_date"],
+                        "envo_term": envo_term,
+                        "system_description": res[6],
+                        "system_term": res[0],
+                    }
+                    try:
+                        results[system].append(entry)
+                    except KeyError:
+                        results[system] = []
+                        results[system].append(entry)
+        return results
+    else:
+        raise ApiException(response.status_code)
 
 
 class ApiException(Exception):

--- a/src/nmdc_geoloc_tools/geotools.py
+++ b/src/nmdc_geoloc_tools/geotools.py
@@ -79,9 +79,7 @@ def elevation(latlon: LATLON) -> float:
         "INFO_FORMAT": "text/xml",
         "BBOX": bbox,
     }
-    response = requests.get(
-        "https://webmap.ornl.gov/ogcbroker/wms", params=elevparams
-    )
+    response = requests.get("https://webmap.ornl.gov/ogcbroker/wms", params=elevparams)
     if response.status_code == 200:
         elevxml = response.content.decode("utf-8")
         if elevxml == "":
@@ -177,9 +175,7 @@ def landuse(latlon: LATLON, start_date, end_date) -> {}:
     start_date_obj = datetime.strptime(start_date, date_format)
     end_date_obj = datetime.strptime(end_date, date_format)
 
-    api_start_date = (
-        "A" + str(start_date_obj.year) + str(start_date_obj.strftime("%j"))
-    )
+    api_start_date = "A" + str(start_date_obj.year) + str(start_date_obj.strftime("%j"))
     api_end_date = "A" + str(end_date_obj.year) + str(end_date_obj.strftime("%j"))
 
     landuse_params = {

--- a/tests/test_geotools.py
+++ b/tests/test_geotools.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 
 from nmdc_geoloc_tools import elevation, fao_soil_type, landuse, landuse_dates
 
@@ -19,6 +20,22 @@ def test_elevation_ocean():
 def test_elevation_bad_coordinates():
     with pytest.raises(ValueError):
         elevation((-200, 200))
+
+
+def test_elevation_caching(mocker):
+    spy = mocker.spy(requests, "get")
+
+    # First call should make a request
+    elevation((45, -120))
+    assert spy.call_count == 1
+
+    # Second call should not make an additional request
+    elevation((45, -120))
+    assert spy.call_count == 1
+
+    # A call with different coordinates should make a request
+    elevation((46, -120))
+    assert spy.call_count == 2
 
 
 def test_soil_type_cambisols():

--- a/tests/test_geotools.py
+++ b/tests/test_geotools.py
@@ -1,54 +1,49 @@
 import pytest
 
-from nmdc_geoloc_tools import GeoEngine
+from nmdc_geoloc_tools import elevation, fao_soil_type, landuse, landuse_dates
 
 
-@pytest.fixture()
-def engine():
-    return GeoEngine()
+def test_elevation_mount_everest():
+    assert int(elevation((27.9881, 86.9250))) == 8752
 
 
-def test_elevation_mount_everest(engine):
-    assert int(engine.get_elevation((27.9881, 86.9250))) == 8752
+def test_elevation_death_valley():
+    assert int(elevation((36.5322649, -116.9325408))) == -66
 
 
-def test_elevation_death_valley(engine):
-    assert int(engine.get_elevation((36.5322649, -116.9325408))) == -66
-
-
-def test_elevation_ocean(engine):
+def test_elevation_ocean():
     with pytest.raises(ValueError):
-        engine.get_elevation((0, 0))
+        elevation((0, 0))
 
 
-def test_elevation_bad_coordinates(engine):
+def test_elevation_bad_coordinates():
     with pytest.raises(ValueError):
-        engine.get_elevation((-200, 200))
+        elevation((-200, 200))
 
 
-def test_soil_type_cambisols(engine):
-    assert engine.get_fao_soil_type((32.95047, -87.393259)) == "Cambisols"
+def test_soil_type_cambisols():
+    assert fao_soil_type((32.95047, -87.393259)) == "Cambisols"
 
 
-def test_soil_type_water(engine):
-    assert engine.get_fao_soil_type((0, 0)) == "Water"
+def test_soil_type_water():
+    assert fao_soil_type((0, 0)) == "Water"
 
 
-def test_soil_type_bad_coordinates(engine):
+def test_soil_type_bad_coordinates():
     with pytest.raises(ValueError):
-        engine.get_fao_soil_type((-200, 200))
+        fao_soil_type((-200, 200))
 
 
-def test_landuse_bad_coordinates(engine):
+def test_landuse_bad_coordinates():
     with pytest.raises(ValueError):
-        engine.get_landuse((-200, 200), "2001-01-01", "2002-01-01")
+        landuse((-200, 200), "2001-01-01", "2002-01-01")
 
 
-def test_landuse_date_death_valley(engine):
-    dates = engine.get_landuse_dates((36.5322649, -116.9325408))
+def test_landuse_date_death_valley():
+    dates = landuse_dates((36.5322649, -116.9325408))
     assert dates[0] == "2001-01-01"
 
 
-def test_landuse_death_valley(engine):
-    data = engine.get_landuse((36.5322649, -116.9325408), "2001-01-01", "2002-01-01")
+def test_landuse_death_valley():
+    data = landuse((36.5322649, -116.9325408), "2001-01-01", "2002-01-01")
     assert data["LCCS1"][0]["envo_term"] == "area of barren land"


### PR DESCRIPTION
Fixes #15 

Adds caching to functions (previously methods) which make calls to ORNL geolocation services. 

These changes also remove the `GeoEngine` class and convert its methods and computed properties into plain functions. The reason for this change is two-fold. First, caching is more straightforward for plain function as compared to methods. Second, the class itself wasn't really doing anything; that is, one instance of `GeoEngine` would never be meaningfully different than another instance. 

Finally, in converting the methods to functions, I changed their names to drop the `get_` prefix to make them more Pythonic.